### PR TITLE
fix(ci): install PyNaCl + always-run web manifest tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Python test dependencies
+        # tools/tests/test_gen_ctrl_key.py needs PyNaCl (or cryptography) to exercise gen_ctrl_key.py's
+        # real keypair generation -- CI never had it installed, so every run since this workflow's
+        # creation failed at that step and (being the default fail-fast step order) never reached the
+        # web manifest tests below. Silent for days: the job showed red, but for the wrong reason.
+        run: pip install pynacl
+
       - name: Build the host harnesses
         run: |
           for d in probe_audit decoy_audit pcap_learn radar_audit; do
@@ -43,6 +50,9 @@ jobs:
           echo "::endgroup::"
 
       - name: Run the web manifest tests
+        # Independent of the tools/ suites above: always run this even if an earlier step in this job
+        # failed, so a break elsewhere can never again silently mask the web-flasher's own tests.
+        if: always()
         run: python -m unittest discover -s web -p 'test_*.py'
 
   # The on-target self-test never runs in CI (it needs hardware), but it must keep COMPILING as the


### PR DESCRIPTION
## What

\`tools/tests/test_gen_ctrl_key.py\` needs PyNaCl or \`cryptography\` to exercise \`gen_ctrl_key.py\`'s real keypair generation. CI never installed either, so that step has failed on every push since this workflow existed (at least back to 2026-08-12) — and because a GitHub Actions job stops at its first failing step by default, the web-manifest tests that come after it in the same job never actually ran in CI, even though they pass locally.

## Fix

1. Install `pynacl` before the `tools/` suites run.
2. Mark the "Run the web manifest tests" step `if: always()`, so an unrelated failure earlier in the job can never again silently mask it.

## Verification

Ran both suites locally with the fix in place:
- `tools/tests/test_gen_ctrl_key.py` — 7/7 pass
- `web/test_manifest.py` — 5/5 pass

No functional code touched — CI workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)