### PR TITLE
docs: contributing policy — issues welcome, PRs not yet

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Something isn't working as documented
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Board(s) and build path**
+Which board(s) — Ward (C5) / Shade (C6) / Vigil (CYD)? Flashed via the
+[browser web-flasher](https://em3ritus.github.io/simulacra/) or built from source? If from source,
+which `-D…` build flags?
+
+**Expected behavior**
+
+**Actual behavior**
+
+**Serial output**
+Paste relevant lines from `idf.py monitor` (or the web-flasher's log), if you have them.
+
+**Anything else**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+**Issues are welcome.** Bug reports, questions, and feature requests — open an issue. That includes
+build/flash problems, console behavior that doesn't match the [wiki](https://github.com/Em3ritus/simulacra/wiki)
+or [README](README.md), and hardware you'd like to see supported.
+
+**Pull requests aren't being merged right now.** Simulacra is currently
+**unlicensed — all rights reserved** (see [License](README.md#license)), and until that's settled,
+accepting outside code raises questions about whose work it even is. Feel free to fork and hack on
+it — just don't expect a PR to land upstream yet. This will change once licensing is sorted; if you
+want to know when, watch the repo or check back.
+
+## Filing a good bug report
+
+Include:
+- Which board(s) and how they're wired/flashed (browser web-flasher vs. built from source; which
+  build flags if from source)
+- What you expected vs. what happened
+- Serial output around the problem, if you have it (`idf.py monitor` or the flasher's own log)
+
+## Security-relevant findings
+
+This is a privacy tool that transmits RF traffic and handles cryptographic keys (fleet transport key,
+CONTROL signing key). If you find something that undermines those specifically — not general bugs,
+but something that leaks identity, forges a signed command, or breaks a stated security guarantee in
+the [Security model](README.md#security-model) — please still just open an issue. There's no formal
+disclosure program; flag it clearly in the title so it doesn't get missed.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ over an encrypted ESP-NOW link.
 [Architecture](#architecture--the-nodes) · [Features](#features) ·
 [Security model](#security-model) · [Hardware](#hardware) · [Build & flash](#build--flash) ·
 [Repo layout](#repository-layout) · [Offline tools](#offline--bench-tools) ·
-[Recent updates](#recent-updates) · [Credits](#credits) · [License](#license) ·
-**[Wiki](https://github.com/Em3ritus/simulacra/wiki)**
+[Recent updates](#recent-updates) · [Contributing](#contributing) · [Credits](#credits) ·
+[License](#license) · **[Wiki](https://github.com/Em3ritus/simulacra/wiki)**
 
 ---
 
@@ -267,6 +267,11 @@ Newest first — full history in [`CHANGELOG.md`](CHANGELOG.md). Forward-looking
   from a web page — ESP Web Tools over Web Serial, auto-detecting the board and installing the right
   role. A CI action builds the three firmwares and deploys the flasher to GitHub Pages on every
   firmware change, so no binaries ever live in git.
+
+## Contributing
+
+**Issues welcome** — bug reports, questions, hardware requests. **PRs aren't being merged yet** — see
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for why and what to expect.
 
 ## Credits
 


### PR DESCRIPTION
## What

Item 3 of the README top-to-bottom cleanup: with more traffic likely bringing issues/PRs from strangers, this states the stance plainly now rather than reactively.

## Changes

- `CONTRIBUTING.md` — bug reports/feature requests welcome via Issues; PRs won't be merged until the unlicensed/all-rights-reserved status is settled. Also covers what a good bug report includes and how to flag a security-relevant finding.
- `.github/ISSUE_TEMPLATE/bug_report.md` — lightweight template (board/build-path, expected vs. actual, serial output) since Issues are now the intended channel.
- README: new Contributing section + jump-to nav entry, both linking to `CONTRIBUTING.md`.

No functional changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)