### PR TITLE
feat(detect): two new Flock signatures from GainSec/BirdShot research

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "simulacra_main.c" "churn_adv.c" "roster.c" "churn_selftest.c" "churn.c" "ble_devices.c" "settings.c" "templates.c" "rf_model.c" "observe.c" "generate.c" "probe.c" "probe_frame.c" "probe_agents.c" "ssid_pool.c" "sniff.c" "espnow_sniff.c" "drift.c" "coexist.c" "detect.c" "webui.c" "esp_now_link.c" "learn.c" "sig_store.c" "fleet.c" "fleet_key.c" "vbat.c" "uniq_id.c" "phantom.c" "fleet_pop.c" "wifi_density.c" "wifi_observe.c" "surveil_oui.c"
+    SRCS "simulacra_main.c" "churn_adv.c" "roster.c" "churn_selftest.c" "churn.c" "ble_devices.c" "settings.c" "templates.c" "rf_model.c" "observe.c" "generate.c" "probe.c" "probe_frame.c" "probe_agents.c" "ssid_pool.c" "sniff.c" "espnow_sniff.c" "drift.c" "coexist.c" "detect.c" "webui.c" "esp_now_link.c" "learn.c" "sig_store.c" "fleet.c" "fleet_key.c" "vbat.c" "uniq_id.c" "phantom.c" "fleet_pop.c" "wifi_density.c" "wifi_observe.c" "surveil_oui.c" "surveil_ble_name.c"
     INCLUDE_DIRS "."
     REQUIRES bt nvs_flash driver esp_adc esp_wifi esp_netif esp_event esp_http_server simulacra_radar
     EMBED_TXTFILES "webui_index.html"

--- a/main/observe.c
+++ b/main/observe.c
@@ -3,6 +3,7 @@
 #include "learn.h"
 #include "sig_match.h"
 #include "sig_store.h"
+#include "surveil_ble_name.h"
 #include "fleet.h"
 #include "esp_log.h"
 
@@ -205,6 +206,18 @@ static int observe_gap_event(struct ble_gap_event *event, void *arg)
             .svc_data = svcd, .svc_len = svcd_len,
         };
         if (sig_match(&sf, sig_store_db(), sig_store_count(), &hit)) hitp = &hit;
+    }
+
+    // Advertised-local-name surveillance-vendor check (independent of the byte-pattern DB above --
+    // doesn't need sig_store seeded, and covers gear identifiable by name rather than a structured
+    // mfg/service-data field, e.g. Flock Raven -- see surveil_ble_name.h). Only runs if the byte-
+    // pattern DB didn't already produce a hit, so a device never double-reports.
+    if (!hitp && parsed && f.name && f.name_len > 0) {
+        uint8_t nclass, ncat;
+        if (surveil_name_match(f.name, f.name_len, &nclass, &ncat)) {
+            hit = (sig_hit_t){ .sig_id = 0xFFFF, .category = ncat, .class_id = nclass, .confidence = 75 };
+            hitp = &hit;
+        }
     }
 
     // legacy_event_type is the PDU type for legacy ads; non-legacy ext ads clamp to the last bin.

--- a/main/surveil_ble_name.c
+++ b/main/surveil_ble_name.c
@@ -1,0 +1,42 @@
+#include "surveil_ble_name.h"
+#include "threat_sig.h"
+#include <stddef.h>
+
+typedef struct { const char *needle; uint8_t len; uint8_t class_id; uint8_t category; } surveil_name_t;
+
+// Advertised-local-name substrings observed on known surveillance gear (case-insensitive). See the
+// header for sourcing. Confidence for a match is the caller's call (this file only identifies the
+// class/category), matching the pattern used elsewhere for a name-only signal.
+static const surveil_name_t NAME_WATCH[] = {
+    { "flock", 5, SIG_CLASS_FLOCK, SIG_CAT_CAMERA },
+};
+#define NAME_WATCH_N (sizeof NAME_WATCH / sizeof NAME_WATCH[0])
+
+static bool ci_contains(const uint8_t *hay, uint8_t hay_len, const char *needle, uint8_t needle_len)
+{
+    if (needle_len == 0 || hay_len < needle_len) return false;
+    for (uint16_t i = 0; i + needle_len <= hay_len; i++) {
+        uint8_t j = 0;
+        for (; j < needle_len; j++) {
+            uint8_t a = hay[i + j], b = (uint8_t)needle[j];
+            if (a >= 'A' && a <= 'Z') a = (uint8_t)(a + 32);
+            if (b >= 'A' && b <= 'Z') b = (uint8_t)(b + 32);
+            if (a != b) break;
+        }
+        if (j == needle_len) return true;
+    }
+    return false;
+}
+
+bool surveil_name_match(const uint8_t *name, uint8_t len, uint8_t *class_id, uint8_t *category)
+{
+    if (!name || len == 0) return false;
+    for (size_t i = 0; i < NAME_WATCH_N; i++) {
+        if (ci_contains(name, len, NAME_WATCH[i].needle, NAME_WATCH[i].len)) {
+            if (class_id) *class_id = NAME_WATCH[i].class_id;
+            if (category) *category = NAME_WATCH[i].category;
+            return true;
+        }
+    }
+    return false;
+}

--- a/main/surveil_ble_name.h
+++ b/main/surveil_ble_name.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+// BLE advertised local-name surveillance-vendor detection. Complements the byte-pattern signature
+// DB (threat_sig.h / sig_seed.c) for gear that's identifiable by its advertised name rather than a
+// structured mfg/service-data field -- e.g. Flock Safety's Raven units, per public research (GainSec
+// / BirdShot, DEF CON 34, confirmed against real hardware: the advertised local name contains
+// "flock"). A name-substring match is weaker evidence than an exact byte-pattern match, so callers
+// should treat it as a lower-confidence signal (see the confidence value returned by the caller).
+
+// Match a BLE advertised local name (Complete or Shortened -- NimBLE's parser already unifies both
+// into one field) against known surveillance-device name substrings, case-insensitive. Returns true
+// (and fills class_id/category, sig_class_t / sig_category_t values) on a hit; false otherwise. Pure.
+// `name` is NOT NUL-terminated; `len` is its byte length.
+bool surveil_name_match(const uint8_t *name, uint8_t len, uint8_t *class_id, uint8_t *category);

--- a/main/surveil_oui.c
+++ b/main/surveil_oui.c
@@ -25,19 +25,30 @@ bool surveil_oui_match(const uint8_t mac[6], uint8_t *class_id, uint8_t *categor
     return false;
 }
 
-typedef struct { const char *ssid; uint8_t len; uint8_t class_id; uint8_t category; } surveil_ssid_t;
+typedef struct { const char *ssid; uint8_t len; bool prefix; uint8_t class_id; uint8_t category; } surveil_ssid_t;
 
-// Surveillance network names probed for by known gear. test_flck: Flock Falcon/Sparrow saved dev
-// network (CVE-2025-59409) -- units probe for it when Wi-Fi is up. Exact, case-sensitive.
+// Surveillance network names, either probed for (a saved dev/test network) or broadcast (a device's
+// own hotspot -- suffix varies per unit, hence prefix match). All exact/prefix, case-sensitive.
+//   test_flck: Flock Falcon/Sparrow saved dev network (CVE-2025-59409) -- units probe for it when
+//     Wi-Fi is up.
+//   "Flock-": Flock devices' own local maintenance hotspot (CVE-2025-47818, hardcoded Wi-Fi
+//     SSID/password) -- confirmed both in BirdShot's own detection code and directly in extracted
+//     firmware strings ("Flock-230503"), and named explicitly in the DEF CON 34 talk as the trigger
+//     condition for the disclosed local-wireless attack chain (GainSec, "Bird Hunting Season: The
+//     Final Flight"). Broadcast by the device itself, so this fires on the beacon path, not probes.
 static const surveil_ssid_t SSID_WATCH[] = {
-    { "test_flck", 9, SIG_CLASS_FLOCK, SIG_CAT_CAMERA },
+    { "test_flck", 9, false, SIG_CLASS_FLOCK, SIG_CAT_CAMERA },
+    { "Flock-",    6, true,  SIG_CLASS_FLOCK, SIG_CAT_CAMERA },
 };
 #define SSID_WATCH_N (sizeof SSID_WATCH / sizeof SSID_WATCH[0])
 
 bool surveil_ssid_match(const uint8_t *ssid, uint8_t len, uint8_t *class_id, uint8_t *category)
 {
     for (size_t i = 0; i < SSID_WATCH_N; i++) {
-        if (len == SSID_WATCH[i].len && memcmp(ssid, SSID_WATCH[i].ssid, len) == 0) {
+        bool hit = SSID_WATCH[i].prefix
+            ? (len >= SSID_WATCH[i].len && memcmp(ssid, SSID_WATCH[i].ssid, SSID_WATCH[i].len) == 0)
+            : (len == SSID_WATCH[i].len && memcmp(ssid, SSID_WATCH[i].ssid, len) == 0);
+        if (hit) {
             if (class_id) *class_id = SSID_WATCH[i].class_id;
             if (category) *category = SSID_WATCH[i].category;
             return true;

--- a/main/surveil_oui.h
+++ b/main/surveil_oui.h
@@ -9,9 +9,10 @@
 // sig_category_t values) on a hit; false otherwise. Pure.
 bool surveil_oui_match(const uint8_t mac[6], uint8_t *class_id, uint8_t *category);
 
-// Match an SSID (exact, case-sensitive) against the surveillance-SSID watchlist. Returns true (and
-// fills class_id/category) on a hit; false otherwise. Pure. `ssid` is NOT NUL-terminated; `len` is the
-// SSID element length.
+// Match an SSID against the surveillance-SSID watchlist -- some entries are exact (a saved/probed
+// network name), others are a prefix (a device's own hotspot, whose suffix varies per unit). Returns
+// true (and fills class_id/category) on a hit; false otherwise. Pure, case-sensitive. `ssid` is NOT
+// NUL-terminated; `len` is the SSID element length.
 bool surveil_ssid_match(const uint8_t *ssid, uint8_t len, uint8_t *class_id, uint8_t *category);
 
 // Seed the per-session hash salt (call once, e.g. surveil_init(esp_random())).

--- a/main/wifi_observe.c
+++ b/main/wifi_observe.c
@@ -20,8 +20,22 @@ static void rx_cb(void *buf, wifi_promiscuous_pkt_type_t type)
         uint32_t bnow = (uint32_t)(esp_timer_get_time() / 1000);
         if (fleet_mac_excluded(bssid, bnow)) return;   // never flag our own fleet
         uint8_t cls, cat;
-        if (surveil_oui_match(bssid, &cls, &cat))
+        if (surveil_oui_match(bssid, &cls, &cat)) {
             surveil_note(surveil_hash(bssid), p->rx_ctrl.rssi, cls, cat);  // Law 1: hash, MAC dropped
+            return;
+        }
+        // A beacon's own SSID vs the watchlist -- e.g. a Flock device's "Flock-<suffix>" maintenance
+        // hotspot (CVE-2025-47818). Beacons carry 12 fixed bytes (timestamp+interval+capability)
+        // between the 24-byte mgmt header and the IEs, unlike a probe request, so the SSID IE sits at
+        // offset 36 here, not 24.
+        if (p->rx_ctrl.sig_len >= 38 && f[36] == 0x00) {           // first IE is the SSID element (id 0)
+            uint8_t slen = f[37];
+            if (slen > 0 && p->rx_ctrl.sig_len >= (uint32_t)(38 + slen)) {
+                uint8_t scls, scat;
+                if (surveil_ssid_match(f + 38, slen, &scls, &scat))
+                    surveil_note(surveil_hash(bssid), p->rx_ctrl.rssi, scls, scat);  // Law 1: hash, MAC dropped
+            }
+        }
         return;
     }
     if (f[0] != 0x40) return;                 // frame control: probe request

--- a/tools/probe_audit/Makefile
+++ b/tools/probe_audit/Makefile
@@ -3,7 +3,7 @@ ROOT := ../..
 # Link-only stub for phantom_sync_ble's ble_devices_count/ble_device_sync -- see the file's own
 # comment for why the real ble_devices.c is deliberately not pulled in here. run.ps1 has always
 # listed it; the Makefile did not, so the POSIX build failed to link.
-SRC := probe_dump.c host_stubs/ble_devices_stub.c $(ROOT)/main/probe_frame.c $(ROOT)/main/probe_agents.c $(ROOT)/main/ssid_pool.c $(ROOT)/main/uniq_id.c $(ROOT)/main/phantom.c $(ROOT)/main/wifi_density.c $(ROOT)/main/surveil_oui.c
+SRC := probe_dump.c host_stubs/ble_devices_stub.c $(ROOT)/main/probe_frame.c $(ROOT)/main/probe_agents.c $(ROOT)/main/ssid_pool.c $(ROOT)/main/uniq_id.c $(ROOT)/main/phantom.c $(ROOT)/main/wifi_density.c $(ROOT)/main/surveil_oui.c $(ROOT)/main/surveil_ble_name.c
 INC := -Ihost_stubs -I$(ROOT)/main -I$(ROOT)/components/simulacra_radar
 CFLAGS ?= -O2 -Wall -Wno-unused-parameter
 all: probe_dump

--- a/tools/probe_audit/probe_dump.c
+++ b/tools/probe_audit/probe_dump.c
@@ -8,6 +8,7 @@
 #include "wifi_density.h"
 #include "ssid_pool.h"
 #include "surveil_oui.h"
+#include "surveil_ble_name.h"
 
 /*
  * Host dumper for the probe-request archetype builder.
@@ -421,6 +422,14 @@ int main(int argc, char **argv)
         const char *s = argc > 2 ? argv[2] : "";
         uint8_t cls = 255, cat = 255;
         int m = surveil_ssid_match((const uint8_t *)s, (uint8_t)strlen(s), &cls, &cat) ? 1 : 0;
+        printf("%d %d %d\n", m, (int)cls, (int)cat);
+        return 0;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "--surveilname") == 0) {   // --surveilname <ascii_ble_name>
+        const char *s = argc > 2 ? argv[2] : "";
+        uint8_t cls = 255, cat = 255;
+        int m = surveil_name_match((const uint8_t *)s, (uint8_t)strlen(s), &cls, &cat) ? 1 : 0;
         printf("%d %d %d\n", m, (int)cls, (int)cat);
         return 0;
     }

--- a/tools/probe_audit/run.ps1
+++ b/tools/probe_audit/run.ps1
@@ -20,7 +20,7 @@ if ($Rebuild -or -not (Test-Path $exe)) {
     try {
         cl /nologo /TC /O2 /D_CRT_SECURE_NO_WARNINGS /FIportab.h `
            /Ihost_stubs /I..\..\main /I..\..\components\simulacra_radar `
-           probe_dump.c ..\..\main\probe_frame.c ..\..\main\probe_agents.c ..\..\main\ssid_pool.c ..\..\main\uniq_id.c ..\..\main\phantom.c host_stubs\ble_devices_stub.c ..\..\main\wifi_density.c ..\..\main\surveil_oui.c /Fe:probe_dump.exe | Out-Null
+           probe_dump.c ..\..\main\probe_frame.c ..\..\main\probe_agents.c ..\..\main\ssid_pool.c ..\..\main\uniq_id.c ..\..\main\phantom.c host_stubs\ble_devices_stub.c ..\..\main\wifi_density.c ..\..\main\surveil_oui.c ..\..\main\surveil_ble_name.c /Fe:probe_dump.exe | Out-Null
         if ($LASTEXITCODE -ne 0) { Write-Error "build failed"; exit 3 }
     } finally { Pop-Location }
 }

--- a/tools/probe_audit/tests/test_surveil.py
+++ b/tools/probe_audit/tests/test_surveil.py
@@ -48,3 +48,42 @@ class SurveilSsid(unittest.TestCase):
     def test_length_prefix_does_not_match(self):
         # exact-length match: an 8-char prefix of the 9-char name must NOT match
         self.assertEqual(ssid_match("test_flc")[0], 0)
+
+    def test_flock_hotspot_prefix_matches(self):
+        # real observed instance from production firmware (GainSec / BirdShot DEF CON 34 research),
+        # CVE-2025-47818 -- SIG_CLASS_FLOCK = 3, SIG_CAT_CAMERA = 1
+        self.assertEqual(ssid_match("Flock-230503"), (1, 3, 1))
+
+    def test_flock_prefix_matches_bare_dash(self):
+        self.assertEqual(ssid_match("Flock-"), (1, 3, 1))
+
+    def test_flock_prefix_requires_the_dash(self):
+        # "Flock" alone, with nothing after it, is not the hotspot's naming convention
+        self.assertEqual(ssid_match("Flock")[0], 0)
+
+    def test_flock_prefix_is_case_sensitive(self):
+        self.assertEqual(ssid_match("flock-230503")[0], 0)
+
+
+def name_match(s):
+    out = subprocess.check_output([EXE, "--surveilname", s], text=True).split()
+    return int(out[0]), int(out[1]), int(out[2])   # matched(0/1), class_id, category
+
+
+@unittest.skipUnless(os.path.exists(EXE), "probe_dump not built")
+class SurveilName(unittest.TestCase):
+    def test_flock_substring_matches_camera(self):
+        # Raven's own BLE advertised local name contains "flock" (GainSec / BirdShot DEF CON 34
+        # research, raven_ble.py's discovery filter, confirmed against real hardware).
+        # SIG_CLASS_FLOCK = 3, SIG_CAT_CAMERA = 1
+        self.assertEqual(name_match("Flock Raven-1A2B"), (1, 3, 1))
+
+    def test_matches_is_case_insensitive(self):
+        self.assertEqual(name_match("FLOCK-DEVICE")[0], 1)
+        self.assertEqual(name_match("myflockthing")[0], 1)
+
+    def test_other_name_does_not_match(self):
+        self.assertEqual(name_match("Galaxy Buds")[0], 0)
+
+    def test_empty_name_does_not_match(self):
+        self.assertEqual(name_match("")[0], 0)


### PR DESCRIPTION
## What

Two new, verified passive detection paths for Flock Safety surveillance gear, sourced from public security research (Jon "GainSec" Gaines, "Bird Hunting Season: The Final Flight," DEF CON 34) — not from BirdShot's own exploitation code, which stays entirely out of scope for this project (it's an active exploitation toolkit for lab-owned hardware; RCE chains, ADB/JDWP shells, video feed capture — none of that belongs here).

## 1. BLE advertised local name containing "flock"

Raven's own BLE discovery filter (`raven_ble.py`), verified directly from the raw source — `pattern: str = "flock"` matched case-insensitively against `dev.name`.

New standalone matcher (`main/surveil_ble_name.*`), parallel to how the Wi-Fi side already handles vendor-identity-by-name matching in `surveil_oui.c` — `threat_sig.h`'s byte-pattern DB has no field for the advertised name, and extending it would be a wire-format change across the whole fleet-synced signature DB (version bump, sync/seed code, CYD deserialization) for what's really an orthogonal signal. Wired into `observe.c` as a fallback only when the byte-pattern DB (`sig_match`) doesn't already produce a hit, so a device is never double-reported.

Confidence=75: real-hardware confirmation via independent research, but a substring/behavioral match rather than an exact byte pattern — higher than the existing 0x09C8 mfg-id-only Flock signature (confidence=60, and per its own comment, an unvalidated module-vendor guess, not Flock-specific).

## 2. Wi-Fi SSID prefix "Flock-"

The device's own local maintenance hotspot (CVE-2025-47818, "hardcoded Wi-Fi SSID/password"), confirmed three independent ways:
- BirdShot's own `_is_flock_ssid()` helper (`ssid.lower().startswith("flock-")`)
- A real instance extracted directly from production firmware strings: `Flock-230503`
- The talk's own slide text, naming it as the trigger condition for the disclosed local-wireless attack chain: *"Device enters a mode where a Flock-named local wireless network becomes reachable from nearby range"*

Extended `surveil_ssid_t` with a prefix-match mode (existing entries stay exact-match, e.g. `test_flck`) and added the entry. Wired into `wifi_observe.c`'s **beacon** path specifically — this is the device's own broadcast AP, not something it probes for, so it never would have fired through the existing probe-request-only SSID check. Beacons carry 12 fixed bytes (timestamp+interval+capability) between the mgmt header and the IEs that a probe request doesn't, so the SSID IE offset differs (36 vs 24).

## Verification

- C5 and C6 firmware both build clean.
- `probe_audit` host suite: **98/98 pass** (90 pre-existing + 8 new — 4 SSID-prefix cases, 4 BLE-name cases, including case-sensitivity/insensitivity checks and a same-length non-match mirroring the existing `test_flck` exact-match test style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)